### PR TITLE
Handle datetime value properly

### DIFF
--- a/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
+++ b/src/main/java/uk/co/certait/htmlexporter/writer/excel/ExcelTableCellWriter.java
@@ -79,6 +79,9 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 		} else if(isPossibleDateCell(element) && (dateValue = getDateValue(element, getDatePattern())) != null) {
 			cell.setCellValue(dateValue);
 			datePattern = getDatePattern();
+		} else if(isPossibleDateTimeCell(element) && (dateValue = getDateTimeValue(element, getDateTimePattern())) != null) {
+			cell.setCellValue(dateValue);
+			datePattern = toExcelDateTimePattern(getDateTimePattern());
 		} else if ((numericValue = getNumericValue(element)) != null) {
 			if (isPercentageCell(element)) {
 				cell.setCellValue(numericValue / 100);
@@ -119,4 +122,18 @@ public class ExcelTableCellWriter extends AbstractTableCellWriter {
 
 		new ExcelFunctionCell(cell, range, new ExcelCellRangeResolver(), function);
 	}
+
+	/**
+	 * Converts a date pattern (e.g. from Java) to one that can be used by Excel.
+	 *
+	 * @param dateTimePattern
+	 * @return
+	 */
+	private String toExcelDateTimePattern(String dateTimePattern) {
+		if(dateTimePattern.matches("^.*a$")) { // 1. Replace 'a' at the end of the pattern with AM/PM
+			return dateTimePattern.substring(0, dateTimePattern.lastIndexOf("a")) + "AM/PM";
+		}
+		return dateTimePattern;
+	}
+
 }


### PR DESCRIPTION
Currently, values that look like datetime e.g. '23/02/2023 - 03:24 PM' will be parsed as numeric value. This caused the resulting Excel to display erroneous data. For example, for datetime '23/02/2023 - 03:24PM', it will be shown as 2.0.

To fix this, we need to:

1. Identify values that look like datetime.
2. Use regex (or other methods) to extract a parseable datetime.
3. Parse the datetime value.
4. Set the cell value and also the corresponding datetime format.